### PR TITLE
Fixed/updated import URL for zeppelin-solidity MintableToken.sol 

### DIFF
--- a/contracts/GustavoCoin.sol
+++ b/contracts/GustavoCoin.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.13;
 
-import 'zeppelin-solidity/contracts/token/MintableToken.sol';
+import 'zeppelin-solidity/contracts/token/ERC20/MintableToken.sol';
 
 contract GustavoCoin is MintableToken {
   string public name = "GUSTAVO COIN";


### PR DESCRIPTION
Updated the import URL in GustavoCoin.sol to the correct URL, so noobs like me can follow the awesome blog post companion and start writing our own ICO contracts

import 'zeppelin-solidity/contracts/token/ERC20/MintableToken.sol';
